### PR TITLE
Ignore commits which would only change the version

### DIFF
--- a/.github/workflows/build_x86_64.yaml
+++ b/.github/workflows/build_x86_64.yaml
@@ -10,7 +10,6 @@ on:
   push:
     branches:
       - "main"
-      - "ignore_commits_only_changing_version"
 
 env:
   CARGO_TERM_COLOR: always
@@ -84,12 +83,9 @@ jobs:
           cargo build --verbose
           cargo test --verbose
           cargo doc
-    - name: Count the number of files other than the versions.txt files were changed
+    - name: Count the number of files other than the versions.txt files, which were changed
       id: changed_files
       run: echo ::set-output name=PREVIOUS_VERSION::$(git diff --name-only -- . ':(exclude)gtk-layer-shell/src/auto/versions.txt' ':(exclude)gtk-layer-shell-sys/src/auto/versions.txt' | wc -l)
-    - name: Print the number of changed files other than the versions.txt files
-      run: |
-            echo "Number of changed files other than the versions.txt files: ${{ steps.changed_files.outputs.PREVIOUS_VERSION }}"
     - name: Create Pull Request when code was committed to main
       if: steps.changed_files.outputs.PREVIOUS_VERSION != '0' && github.event_name == 'schedule'
       uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/build_x86_64.yaml
+++ b/.github/workflows/build_x86_64.yaml
@@ -86,13 +86,13 @@ jobs:
           cargo doc
     - name: Count the number of files other than the versions.txt files were changed
       run: |
-        FILES_CHANGED=$(git diff --name-only -- . ':(exclude)gtk-layer-shell/src/auto/versions.txt' ':(exclude)gtk-layer-shell-sys/src/auto/versions.txt' | wc -l) &&
-        echo "::set-output name=FILES_CHANGED::$FILES_CHANGED"
+        echo ::set-output name=PREVIOUS_VERSION::$(git diff --name-only -- . ':(exclude)gtk-layer-shell/src/auto/versions.txt' ':(exclude)gtk-layer-shell-sys/src/auto/versions.txt' | wc -l)
+
     - name: Print the number of changed files other than the versions.txt files
-      run: echo ${{steps.main.outputs.FILES_CHANGED}}
+      run: echo "Number of changed files other than the versions.txt files: ${{ steps.previous_version.outputs.PREVIOUS_VERSION }}"
     - name: Create Pull Request when code was committed to main
       if: |
-        ${{steps.main.outputs.FILES_CHANGED > 0}}
+        ${{steps.main.outputs.PREVIOUS_VERSION > 0}}
           && ${{ github.event_name == 'schedule' }}
       uses: stefanzweifel/git-auto-commit-action@v4
       with:

--- a/.github/workflows/build_x86_64.yaml
+++ b/.github/workflows/build_x86_64.yaml
@@ -90,7 +90,12 @@ jobs:
             echo "::set-output name=NOT_ONLY_VERSION_CHANGE::$NOT_ONLY_VERSION_CHANGE"
 
     - name: Print the result of the comparison of strings
-      run: echo ${{steps.main.outputs.NOT_ONLY_VERSION_CHANGE}}
+      run: |
+        if ${{steps.main.outputs.NOT_ONLY_VERSION_CHANGE}}; then
+          echo "NOT ONLY the versions were changed"
+        else
+          echo "ONLY the versions were changed"
+        fi
     - name: Create Pull Request when code was committed to main
       if: |
         ${{steps.main.outputs.NOT_ONLY_VERSION_CHANGE}}

--- a/.github/workflows/build_x86_64.yaml
+++ b/.github/workflows/build_x86_64.yaml
@@ -91,7 +91,7 @@ jobs:
       run: |
             echo "Number of changed files other than the versions.txt files: ${{ steps.changed_files.outputs.PREVIOUS_VERSION }}"
     - name: Create Pull Request when code was committed to main
-      if: ${{steps.changed_files.outputs.PREVIOUS_VERSION != '0'}}
+      if: ${{steps.changed_files.outputs.PREVIOUS_VERSION != '0'}} && ${{ github.event_name == 'schedule' }}
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
         commit_message: Github Actions updated the version

--- a/.github/workflows/build_x86_64.yaml
+++ b/.github/workflows/build_x86_64.yaml
@@ -87,7 +87,8 @@ jobs:
     - name: Count the number of files other than the versions.txt files were changed
       run: echo ::set-output name=PREVIOUS_VERSION::$(git diff --name-only -- . ':(exclude)gtk-layer-shell/src/auto/versions.txt' ':(exclude)gtk-layer-shell-sys/src/auto/versions.txt' | wc -l)
     - name: Print the number of changed files other than the versions.txt files
-      run: echo "Number of changed files other than the versions.txt files: ${{ steps.previous_version.outputs.PREVIOUS_VERSION }}"
+      run: |
+            echo "Number of changed files other than the versions.txt files: ${{ steps.previous_version.outputs.PREVIOUS_VERSION }}"
     - name: Create Pull Request when code was committed to main
       if: |
         ${{steps.main.outputs.PREVIOUS_VERSION > 0}}

--- a/.github/workflows/build_x86_64.yaml
+++ b/.github/workflows/build_x86_64.yaml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - "main"
+      - "ignore_commits_only_changing_version"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/build_x86_64.yaml
+++ b/.github/workflows/build_x86_64.yaml
@@ -85,15 +85,14 @@ jobs:
           cargo test --verbose
           cargo doc
     - name: Count the number of files other than the versions.txt files were changed
-      run: |
-            OUTPUT=$(git diff --name-only -- . ':(exclude)gtk-layer-shell/src/auto/versions.txt' ':(exclude)gtk-layer-shell-sys/src/auto/versions.txt' | wc -l) &&
-            echo "::set-output name=PREVIOUS_VERSION::$OUTPUT"
+        id: changed_files
+      run: echo ::set-output name=PREVIOUS_VERSION::$(git diff --name-only -- . ':(exclude)gtk-layer-shell/src/auto/versions.txt' ':(exclude)gtk-layer-shell-sys/src/auto/versions.txt' | wc -l)
     - name: Print the number of changed files other than the versions.txt files
       run: |
-            echo "Number of changed files other than the versions.txt files: ${{ steps.previous_version.outputs.PREVIOUS_VERSION }}"
+            echo "Number of changed files other than the versions.txt files: ${{ steps.changed_files.outputs.PREVIOUS_VERSION }}"
     - name: Create Pull Request when code was committed to main
       if: |
-        ${{steps.main.outputs.PREVIOUS_VERSION -gt 0}}
+        ${{steps.changed_files.outputs.PREVIOUS_VERSION > 0}}
           && ${{ github.event_name == 'schedule' }}
       uses: stefanzweifel/git-auto-commit-action@v4
       with:

--- a/.github/workflows/build_x86_64.yaml
+++ b/.github/workflows/build_x86_64.yaml
@@ -85,7 +85,9 @@ jobs:
           cargo test --verbose
           cargo doc
     - name: Count the number of files other than the versions.txt files were changed
-      run: echo ::set-output name=PREVIOUS_VERSION::$(git diff --name-only -- . ':(exclude)gtk-layer-shell/src/auto/versions.txt' ':(exclude)gtk-layer-shell-sys/src/auto/versions.txt' | wc -l)
+      run: |
+            OUTPUT=$(git diff --name-only -- . ':(exclude)gtk-layer-shell/src/auto/versions.txt' ':(exclude)gtk-layer-shell-sys/src/auto/versions.txt' | wc -l) &&
+            echo "::set-output name=PREVIOUS_VERSION::$OUTPUT"
     - name: Print the number of changed files other than the versions.txt files
       run: |
             echo "Number of changed files other than the versions.txt files: ${{ steps.previous_version.outputs.PREVIOUS_VERSION }}"

--- a/.github/workflows/build_x86_64.yaml
+++ b/.github/workflows/build_x86_64.yaml
@@ -85,9 +85,7 @@ jobs:
           cargo test --verbose
           cargo doc
     - name: Count the number of files other than the versions.txt files were changed
-      run: |
-        echo ::set-output name=PREVIOUS_VERSION::$(git diff --name-only -- . ':(exclude)gtk-layer-shell/src/auto/versions.txt' ':(exclude)gtk-layer-shell-sys/src/auto/versions.txt' | wc -l)
-
+      run: echo ::set-output name=PREVIOUS_VERSION::$(git diff --name-only -- . ':(exclude)gtk-layer-shell/src/auto/versions.txt' ':(exclude)gtk-layer-shell-sys/src/auto/versions.txt' | wc -l)
     - name: Print the number of changed files other than the versions.txt files
       run: echo "Number of changed files other than the versions.txt files: ${{ steps.previous_version.outputs.PREVIOUS_VERSION }}"
     - name: Create Pull Request when code was committed to main

--- a/.github/workflows/build_x86_64.yaml
+++ b/.github/workflows/build_x86_64.yaml
@@ -91,8 +91,7 @@ jobs:
       run: |
             echo "Number of changed files other than the versions.txt files: ${{ steps.changed_files.outputs.PREVIOUS_VERSION }}"
     - name: Create Pull Request when code was committed to main
-      if: |
-        ${{ github.event_name == 'schedule' }}
+      if: ${{ github.event_name == 'schedule' }}
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
         commit_message: Github Actions updated the version

--- a/.github/workflows/build_x86_64.yaml
+++ b/.github/workflows/build_x86_64.yaml
@@ -91,7 +91,7 @@ jobs:
             echo "Number of changed files other than the versions.txt files: ${{ steps.previous_version.outputs.PREVIOUS_VERSION }}"
     - name: Create Pull Request when code was committed to main
       if: |
-        ${{steps.main.outputs.PREVIOUS_VERSION > 0}}
+        ${{steps.main.outputs.PREVIOUS_VERSION -gt 0}}
           && ${{ github.event_name == 'schedule' }}
       uses: stefanzweifel/git-auto-commit-action@v4
       with:

--- a/.github/workflows/build_x86_64.yaml
+++ b/.github/workflows/build_x86_64.yaml
@@ -86,19 +86,21 @@ jobs:
           cargo doc
     - name: Check if only the version files were changed
       run: |
-            NOT_ONLY_VERSION_CHANGE=$([ "git diff --name-only" != "printf 'gtk-layer-shell-sys/src/auto/versions.txt\ngtk-layer-shell/src/auto/versions.txt\n'" ]) &&
-            echo "::set-output name=NOT_ONLY_VERSION_CHANGE::$NOT_ONLY_VERSION_CHANGE"
+        VAR1=$(git diff --name-only)
+        VAR2="gtk-layer-shell-sys/src/auto/versions.txt\ngtk-layer-shell/src/auto/versions.txt\n"
 
-    - name: Print the result of the comparison of strings
-      run: |
-        if ${{steps.main.outputs.NOT_ONLY_VERSION_CHANGE}}; then
-          echo "NOT ONLY the versions were changed"
+        if [ "$VAR1" = "$VAR2" ]; then
+            OUTPUT="true"
         else
-          echo "ONLY the versions were changed"
+            OUTPUT="false"
         fi
+        echo "::set-output name=ONLY_VERSION_CHANGE::$OUTPUT"
+    - name: Check if only the version files were changed
+      run: echo ${{steps.main.outputs.ONLY_VERSION_CHANGE}}
+
     - name: Create Pull Request when code was committed to main
       if: |
-        ${{steps.main.outputs.NOT_ONLY_VERSION_CHANGE}}
+        ${{steps.main.outputs.ONLY_VERSION_CHANGE == 'false'}}
           && ${{ github.event_name == 'schedule' }}
       uses: stefanzweifel/git-auto-commit-action@v4
       with:

--- a/.github/workflows/build_x86_64.yaml
+++ b/.github/workflows/build_x86_64.yaml
@@ -84,23 +84,15 @@ jobs:
           cargo build --verbose
           cargo test --verbose
           cargo doc
-    - name: Check if only the version files were changed
+    - name: Count the number of files other than the versions.txt files were changed
       run: |
-        VAR1=$(git diff --name-only)
-        VAR2="gtk-layer-shell-sys/src/auto/versions.txt\ngtk-layer-shell/src/auto/versions.txt\n"
-
-        if [ "$VAR1" = "$VAR2" ]; then
-            OUTPUT="true"
-        else
-            OUTPUT="false"
-        fi
-        echo "::set-output name=ONLY_VERSION_CHANGE::$OUTPUT"
-    - name: Check if only the version files were changed
-      run: echo ${{steps.main.outputs.ONLY_VERSION_CHANGE}}
-
+        FILES_CHANGED=$(git diff --name-only -- . ':(exclude)gtk-layer-shell/src/auto/versions.txt' ':(exclude)gtk-layer-shell-sys/src/auto/versions.txt' | wc -l) &&
+        echo "::set-output name=FILES_CHANGED::$FILES_CHANGED"
+    - name: Print the number of changed files other than the versions.txt files
+      run: echo ${{steps.main.outputs.FILES_CHANGED}}
     - name: Create Pull Request when code was committed to main
       if: |
-        ${{steps.main.outputs.ONLY_VERSION_CHANGE == 'false'}}
+        ${{steps.main.outputs.FILES_CHANGED > 0}}
           && ${{ github.event_name == 'schedule' }}
       uses: stefanzweifel/git-auto-commit-action@v4
       with:

--- a/.github/workflows/build_x86_64.yaml
+++ b/.github/workflows/build_x86_64.yaml
@@ -85,7 +85,7 @@ jobs:
           cargo test --verbose
           cargo doc
     - name: Count the number of files other than the versions.txt files were changed
-        id: changed_files
+      id: changed_files
       run: echo ::set-output name=PREVIOUS_VERSION::$(git diff --name-only -- . ':(exclude)gtk-layer-shell/src/auto/versions.txt' ':(exclude)gtk-layer-shell-sys/src/auto/versions.txt' | wc -l)
     - name: Print the number of changed files other than the versions.txt files
       run: |

--- a/.github/workflows/build_x86_64.yaml
+++ b/.github/workflows/build_x86_64.yaml
@@ -83,8 +83,17 @@ jobs:
           cargo build --verbose
           cargo test --verbose
           cargo doc
+    - name: Check if only the version files were changed
+      run: |
+            NOT_ONLY_VERSION_CHANGE=$([ "git diff --name-only" != "printf 'gtk-layer-shell-sys/src/auto/versions.txt\ngtk-layer-shell/src/auto/versions.txt\n'" ]) &&
+            echo "::set-output name=NOT_ONLY_VERSION_CHANGE::$NOT_ONLY_VERSION_CHANGE"
+
+    - name: Print the result of the comparison of strings
+      run: echo ${{steps.main.outputs.NOT_ONLY_VERSION_CHANGE}}
     - name: Create Pull Request when code was committed to main
-      if: ${{ github.event_name == 'schedule' }}
+      if: |
+        ${{steps.main.outputs.NOT_ONLY_VERSION_CHANGE}}
+          && ${{ github.event_name == 'schedule' }}
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
         commit_message: Github Actions updated the version

--- a/.github/workflows/build_x86_64.yaml
+++ b/.github/workflows/build_x86_64.yaml
@@ -91,7 +91,7 @@ jobs:
       run: |
             echo "Number of changed files other than the versions.txt files: ${{ steps.changed_files.outputs.PREVIOUS_VERSION }}"
     - name: Create Pull Request when code was committed to main
-      if: ${{ github.event_name == 'schedule' }}
+      if: ${{steps.changed_files.outputs.PREVIOUS_VERSION != '0'}}
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
         commit_message: Github Actions updated the version

--- a/.github/workflows/build_x86_64.yaml
+++ b/.github/workflows/build_x86_64.yaml
@@ -92,7 +92,7 @@ jobs:
             echo "Number of changed files other than the versions.txt files: ${{ steps.changed_files.outputs.PREVIOUS_VERSION }}"
     - name: Create Pull Request when code was committed to main
       if: |
-        ${{steps.changed_files.outputs.PREVIOUS_VERSION > 0}}
+        ${{steps.changed_files.outputs.PREVIOUS_VERSION != '0'}}
           && ${{ github.event_name == 'schedule' }}
       uses: stefanzweifel/git-auto-commit-action@v4
       with:

--- a/.github/workflows/build_x86_64.yaml
+++ b/.github/workflows/build_x86_64.yaml
@@ -91,7 +91,7 @@ jobs:
       run: |
             echo "Number of changed files other than the versions.txt files: ${{ steps.changed_files.outputs.PREVIOUS_VERSION }}"
     - name: Create Pull Request when code was committed to main
-      if: ${{steps.changed_files.outputs.PREVIOUS_VERSION != '0'}} && ${{ github.event_name == 'schedule' }}
+      if: steps.changed_files.outputs.PREVIOUS_VERSION != '0' && github.event_name == 'schedule'
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
         commit_message: Github Actions updated the version

--- a/.github/workflows/build_x86_64.yaml
+++ b/.github/workflows/build_x86_64.yaml
@@ -92,8 +92,7 @@ jobs:
             echo "Number of changed files other than the versions.txt files: ${{ steps.changed_files.outputs.PREVIOUS_VERSION }}"
     - name: Create Pull Request when code was committed to main
       if: |
-        ${{steps.changed_files.outputs.PREVIOUS_VERSION != '0'}}
-          && ${{ github.event_name == 'schedule' }}
+        ${{ github.event_name == 'schedule' }}
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
         commit_message: Github Actions updated the version


### PR DESCRIPTION
Each night the workflow runs and sometimes only the versions.txt files are changed because of a new Rust version or something similar. These commits are useless so they can be ignored