### PR TITLE
Fail action if output of gir commands has an error

### DIFF
--- a/.github/actions/build_test_commit/action.yaml
+++ b/.github/actions/build_test_commit/action.yaml
@@ -29,13 +29,13 @@ runs:
       run: |
         ls
         export PATH=$PATH:/github/home/.cargo/bin
-        gir -o .
         if [[ $(gir -o . | head -c1 | wc -c) -ne 0 ]]; then
           exit 1
         fi
         if [[ $(gir -o . -m not_bound | head -c1 | wc -c) -ne 0 ]]; then
           exit 1
         fi
+        gir -c Gir.toml -d ../gir-files --doc-target-path docs.md -m doc
         if [[ $(gir -c Gir.toml -d ../gir-files --doc-target-path docs.md -m doc | head -c1 | wc -c) -ne 0 ]]; then
           exit 1
         fi

--- a/.github/actions/build_test_commit/action.yaml
+++ b/.github/actions/build_test_commit/action.yaml
@@ -16,7 +16,7 @@ runs:
         ls
         export PATH=$PATH:/github/home/.cargo/bin
         # Test if there is any output to the gir command
-        if [[ $(gir -o . |& head -c1 | wc -c) -ne 0 ]]; then 
+        if [[ $(gir -o . |& wc -l) -ne 0 ]]; then 
           echo "gir -o failed"
           exit 1
         fi
@@ -30,15 +30,17 @@ runs:
       run: |
         ls
         export PATH=$PATH:/github/home/.cargo/bin
-        if [[ $(gir -o . |& head -c1 | wc -c) -ne 0 ]]; then
+        if [[ $(gir -o . |& wc -l) -ne 0 ]]; then
           echo "gir -o failed"
           exit 1
         fi
-        if [[ $(gir -o . -m not_bound |& head -c1 | wc -c) -ne 0 ]]; then
+        if [[ $(gir -o . -m not_bound |& wc -l) -ne 0 ]]; then
           echo "gir not_bound failed"
           exit 1
         fi
-        if [[ $(gir -c Gir.toml -d ../gir-files --doc-target-path docs.md -m doc |& head -c1 | wc -c) -ne 0 ]]; then
+        # Generating the docs creates a warning. The fix has been upstreamed but until there is a new release of gtk-layer-shell, there will be two warnings
+        # Once the new version is released, this comparison can be changed to 0 instead of 2.
+        if [[ $(gir -c Gir.toml -d ../gir-files --doc-target-path docs.md -m doc |& wc -l) -ne 2 ]]; then
           echo "gir docs failed"
           exit 1
         fi

--- a/.github/actions/build_test_commit/action.yaml
+++ b/.github/actions/build_test_commit/action.yaml
@@ -16,7 +16,8 @@ runs:
         ls
         export PATH=$PATH:/github/home/.cargo/bin
         # Test if there is any output to the gir command
-        if [[ $(gir -o . | head -c1 | wc -c) -ne 0 ]]; then 
+        if [[ $(gir -o . |& head -c1 | wc -c) -ne 0 ]]; then 
+          echo "gir -o failed"
           exit 1
         fi
         cargo update
@@ -29,14 +30,16 @@ runs:
       run: |
         ls
         export PATH=$PATH:/github/home/.cargo/bin
-        if [[ $(gir -o . | head -c1 | wc -c) -ne 0 ]]; then
+        if [[ $(gir -o . |& head -c1 | wc -c) -ne 0 ]]; then
+          echo "gir -o failed"
           exit 1
         fi
-        if [[ $(gir -o . -m not_bound | head -c1 | wc -c) -ne 0 ]]; then
+        if [[ $(gir -o . -m not_bound |& head -c1 | wc -c) -ne 0 ]]; then
+          echo "gir not_bound failed"
           exit 1
         fi
-        gir -c Gir.toml -d ../gir-files --doc-target-path docs.md -m doc
-        if [[ $(gir -c Gir.toml -d ../gir-files --doc-target-path docs.md -m doc | head -c1 | wc -c) -ne 0 ]]; then
+        if [[ $(gir -c Gir.toml -d ../gir-files --doc-target-path docs.md -m doc |& head -c1 | wc -c) -ne 0 ]]; then
+          echo "gir docs failed"
           exit 1
         fi
         cargo install rustdoc-stripper --force

--- a/.github/actions/build_test_commit/action.yaml
+++ b/.github/actions/build_test_commit/action.yaml
@@ -15,9 +15,14 @@ runs:
       run: |
         ls
         export PATH=$PATH:/github/home/.cargo/bin
-        gir -o .
+        # Test if there is any output to the gir command
+        if [[ $(gir -o . | head -c1 | wc -c) -ne 0 ]]; then 
+          exit 1
+        fi
+        cargo update
         cargo build --verbose
         cargo test --verbose
+    # Exit with an error if there is any output of the gir commands, because then there might be some wrongly generated code or errors
     - name: Build and test the wrapper crate
       shell: bash
       working-directory: ./gtk-layer-shell/
@@ -25,10 +30,19 @@ runs:
         ls
         export PATH=$PATH:/github/home/.cargo/bin
         gir -o .
-        gir -c Gir.toml -d ../gir-files --doc-target-path docs.md -m doc
+        if [[ $(gir -o . | head -c1 | wc -c) -ne 0 ]]; then
+          exit 1
+        fi
+        if [[ $(gir -o . -m not_bound | head -c1 | wc -c) -ne 0 ]]; then
+          exit 1
+        fi
+        if [[ $(gir -c Gir.toml -d ../gir-files --doc-target-path docs.md -m doc | head -c1 | wc -c) -ne 0 ]]; then
+          exit 1
+        fi
         cargo install rustdoc-stripper --force
         rustdoc-stripper -s -n
         rustdoc-stripper -g -o docs.md
+        cargo update
         cargo build --verbose
         cargo test --verbose
         cargo doc


### PR DESCRIPTION
The gir commands can have an error or warning. This does not terminate the workflow but it should because there might be errors with the generated code. That's why there now is a check and the workflow fails. For now the doc generation has two warnings, but they have been fixed upstream. It just takes some time for a new release and it making it into the Ubuntu packages. For now they are ignored