### PR TITLE
Replaced set-output command in Github Actions

### DIFF
--- a/.github/actions/build_test_commit/action.yaml
+++ b/.github/actions/build_test_commit/action.yaml
@@ -60,7 +60,7 @@ runs:
       id: changed_files
       shell: bash
       if: ${{ inputs.commit_message != '' }}
-      run: echo ::set-output name=NO_CHANGED_FILES::$(git diff --name-only -- . ':(exclude)gtk-layer-shell/src/auto/versions.txt' ':(exclude)gtk-layer-shell-sys/src/auto/versions.txt' ':(exclude)gir' | wc -l)
+      run: echo "NO_CHANGED_FILES=$(git diff --name-only -- . ':(exclude)gtk-layer-shell/src/auto/versions.txt' ':(exclude)gtk-layer-shell-sys/src/auto/versions.txt' ':(exclude)gir' | wc -l)" >> $GITHUB_OUTPUT
     - name: Commit code changes to main
       if: inputs.commit_message != '' && steps.changed_files.outputs.NO_CHANGED_FILES != '0'
       uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Get the version number
         id: previous_version
         run: |
-          echo ::set-output name=PREVIOUS_VERSION::$(grep -o -m 1 -P '(?<=version = ").*(?=")' ./${{ env.CRATE_PATH }}/Cargo.toml)
+          echo "PREVIOUS_VERSION=$(grep -o -m 1 -P '(?<=version = ").*(?=")' ./${{ env.CRATE_PATH }}/Cargo.toml)" >> $GITHUB_OUTPUT
       - name: Output the version numbers
         run: |
           echo "Previous version: ${{ steps.previous_version.outputs.PREVIOUS_VERSION }}"

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Get the first character of the version of the gtk-layer-shell package to detect mayor version bumps
         id: major_version_check
         run: |
-          echo ::set-output name=MAJOR_VERSION::$(dpkg -s libgtk-layer-shell-dev | grep Version | sed 's/Version. 0.//' | cut -c1-1)
+          echo "MAJOR_VERSION=$(dpkg -s libgtk-layer-shell-dev | grep Version | sed 's/Version. 0.//' | cut -c1-1)" >> $GITHUB_OUTPUT
           echo "Version: ${{ steps.major_version_check.outputs.MAJOR_VERSION }}"
       - name: Fail if mayor version was increased
         if: steps.major_version_check.outputs.MAJOR_VERSION != '7'


### PR DESCRIPTION
The set-output command is deprecated and was replaced