### PR TITLE
Specify resolver 2 to get rid of a warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,4 @@
 [workspace]
 members = ["gtk-layer-shell", "gtk-layer-shell-sys"]
 exclude = ["gir"]
+resolver = "2"


### PR DESCRIPTION
Without specifying the resolver in the workspace's Cargo.toml file, there is the following warning:

 ```
[user@host gtk-layer-shell-gir]$ cargo build
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

Resolver 2 was specified to get rid of it.