### PR TITLE
Bump glib to 0.18

### DIFF
--- a/gtk-layer-shell-sys/Cargo.toml
+++ b/gtk-layer-shell-sys/Cargo.toml
@@ -35,7 +35,7 @@ libc = "0.2"
 
 [dependencies.glib]
 package = "glib-sys"
-version = "0.17"
+version = "0.18"
 
 [dependencies.gdk]
 package = "gdk-sys"
@@ -57,4 +57,4 @@ v0_4 = []
 v0_5 = ["v0_4"]
 v0_6 = ["v0_5"]
 default = []
-dox = ["glib/dox", "gdk/dox", "gtk/dox"]
+dox = ["gdk/dox", "gtk/dox"]

--- a/gtk-layer-shell/Cargo.toml
+++ b/gtk-layer-shell/Cargo.toml
@@ -16,8 +16,8 @@ features = ["dox"]
 [dependencies]
 libc = "0.2.122"
 bitflags = "2.0"
-glib = "0.17"
-glib-sys = "0.17"
+glib = "0.18"
+glib-sys = "0.18"
 gdk = { version = "0.17", features = ["v3_24"] }
 gtk = "0.17"
 ffi = { package = "gtk-layer-shell-sys", path = "../gtk-layer-shell-sys", version = "0.6" }
@@ -30,4 +30,4 @@ v0_4 = ["ffi/v0_4"]
 v0_5 = ["ffi/v0_5", "v0_4"]
 v0_6 = ["ffi/v0_6", "v0_5"]
 default = []
-dox = ["glib/dox", "glib-sys/dox", "gdk/dox", "gtk/dox", "ffi/dox"]
+dox = ["gdk/dox", "gtk/dox", "ffi/dox"]


### PR DESCRIPTION
glib and glib-sys 0.18 were released. They no longer have the dox feature, because it became obsolete.